### PR TITLE
Allow user to watch non labeled resources across namespaces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,9 @@
     },
     "extends": "eslint:recommended",
     "rules": {
+        "no-console": [
+          "error"
+        ],
         "indent": [
           "error",
           2,

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 script:
   # Audit npm packages. Fail build whan a PR audit fails, otherwise report the vulnerability and proceed.
-  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npx audit-ci --low; else npx audit-ci --low || true; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npx audit-ci --low -w acorn; else npx audit-ci --low || true; fi
   - npm run lint
   - npm test
   - docker build --rm -t "quay.io/razee/watch-keeper:${TRAVIS_COMMIT}" .

--- a/README.md
+++ b/README.md
@@ -124,11 +124,9 @@ data:
 
 ### White/Black Lists
 
-You can white or black list resources by creating a ConfigMap named
+You can white or black list resources by modifying the ConfigMap named
 `watch-keeper-limit-poll`, in the namespace your Watch-Keeper is running.
 
-- When creating the ConfigMap for the first time, you will need to restart the
-Watch-Keeper pods so that it can pick up the volume mount.
 - If both a whitelist and blacklist are specified, only the whitelist will be used.
 - The white/black list is employed during the **Polling**, **Namespace** and **Non-Namespaced**
 [collection methods](#Collection-Methods). Any individual resource specifically

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ labeled to be watched will still be watched, regardless of the white/black list.
 
 - To create your white/black list, the ConfigMap will specify the kind of list
 you want as the first key, and the rest of the ConfigMap entries become the white/black list.
-- The white/black list itself is a JSON string:
+- The white/black list itself are the ConfigMap entries:
   - The keys will be `apiVersion_kind` (where any `/` is replaced with an `_`).
   - The value will be `'true'`.
 

--- a/README.md
+++ b/README.md
@@ -4,53 +4,80 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=razee-io/Watch-keeper)](https://dependabot.com)
 ![GitHub](https://img.shields.io/github/license/razee-io/Watch-keeper.svg?color=success)
 
-Watch-Keeper is a tool that inventories and reports back the resources running on your cluster. Watch-Keeper works with [RazeeDash](https://github.com/razee-io/Razeedash) to display information about your resources.
+Watch-Keeper is a tool that inventories and reports back the resources running on
+your cluster. Watch-Keeper works with [RazeeDash](https://github.com/razee-io/Razeedash)
+to display information about your resources.
 
 ## Install
 
 ### Via RazeeDash
 
-1. [Install RazeeDash](https://github.com/razee-io/Razee#step-1-install-razee) or use a hosted razee such as [razee.io](https://app.razee.io).
+1. [Install RazeeDash](https://github.com/razee-io/Razee#step-1-install-razee)
+or use a hosted razee such as [razee.io](https://app.razee.io).
 1. Add your Github org to your razee.
-1. Go to `https://<razeedash-url>/<your-org-name>/org` then copy and run the `kubectl command` against your new cluster to install the watch-keeper components.
+1. Go to `https://<razeedash-url>/<your-org-name>/org` then copy and run the
+`kubectl command` against your new cluster to install the watch-keeper components.
 
 ### Manually
 
-1. `kubectl create cm watch-keeper-config --from-literal=RAZEEDASH_URL=<path to razeedash api> --from-literal=START_DELAY_MAX=0`
-    - eg. `kubectl create cm watch-keeper-config --from-literal=RAZEEDASH_URL=http://app.razee.io/api/v2 --from-literal=START_DELAY_MAX=0`
-1. `kubectl create secret generic watch-keeper-secret --from-literal=RAZEEDASH_ORG_KEY=<plain text org api key to auth with razeedash>`
+1. `kubectl create cm watch-keeper-config --from-literal=RAZEEDASH_URL=<path-to-razeedash-api>
+ --from-literal=START_DELAY_MAX=0`
+    - eg. `kubectl create cm watch-keeper-config --from- literal=RAZEEDASH_URL=http://app.razee.io/api/v2
+     --from-literal=START_DELAY_MAX=0`
+1. `kubectl create secret generic watch-keeper-secret --from-literal=RAZEEDASH_ORG_KEY=<plain-text-org-api-key-to-auth-with-razeedash>`
     - eg. `kubectl create secret generic watch-keeper-secret --from-literal=RAZEEDASH_ORG_KEY=orgApiKey-88888888-4444-4444-4444-121212121212`
 1. `kubectl apply -f https://github.com/razee-io/Watch-keeper/releases/latest/download/resource.yaml`
 
 ## Collecting Resources
 
-### Collection Methods:
+### Collection Methods
 
-1. Watches: this is where watch-keeper gets its name. Watch-keeper creates watches on any resource with the label `razee/watch-resource=<level>`, and reports to razeedash whenever a change occurs.
-1. Polling: any resource with the `razee/watch-resource=<level>` label is reported. This is useful for resources that are not watchable.
-1. Namespaces: you can gather info from a cluster by labeling a namespace with `razee/watch-resource=<level>`. This will collect and report all data within the labeled namespace at the desired `<level>`. Info is only gathered on the polling cycle. See [white/black lists](#whiteblack-lists) to limit what is collected.
-1. Non-Namespaced Resources: you can gather info about resources that are not bound to a namespace by adding the key `poll` to the `watch-keeper-non-namespaced` ConfigMap. Info is only gathered on the polling cycle. See [white/black lists](#whiteblack-lists) to limit what is collected. See [Non-Namespaced Resources](#non-namespaced-resources) for more info.
-1. Watch by Resource: this allows you to watch and see immediate updates on any resource kind. This can be useful to watch for changes on non-namespaced resource, such as nodes or namespaces, without having to label each resource individually. This can also be useful to watch a single resource type, such as deployments, across the whole cluster. See [Watch By Resource](#watch-by-resource) for more info.
+1. Watches: this is where watch-keeper gets its name. Watch-keeper creates watches
+on any resource with the label `razee/watch-resource=<level>`, and reports to razeedash
+whenever a change occurs.
+1. Polling: any resource with the `razee/watch-resource=<level>` label is reported.
+This is useful for resources that are not watchable.
+1. Namespaces: you can gather info from a cluster by labeling a namespace with
+`razee/watch-resource=<level>`. This will collect and report all data within the
+labeled namespace at the desired `<level>`. Info is only gathered on the polling
+cycle. See [white/black lists](#whiteblack-lists) to limit what is collected.
+1. Non-Namespaced Resources: you can gather info about resources that are not bound
+to a namespace by adding the key `poll` to the `watch-keeper-non-namespaced` ConfigMap.
+Info is only gathered on the polling cycle. See [white/black lists](#whiteblack-lists)
+to limit what is collected. See [Non-Namespaced Resources](#non-namespaced-resources)
+for more info.
+1. Watch by Resource: this allows you to watch and see immediate updates on any
+resource kind. This can be useful to watch for changes on non-namespaced resource,
+such as nodes or namespaces, without having to label each resource individually.
+This can also be useful to watch a single resource type, such as deployments, across
+the whole cluster. See [Watch By Resource](#watch-by-resource) for more info.
 
 - Ex. `kubectl label cm my-cm razee/watch-resource=lite`
 
-### Collection Levels:
+### Collection Levels
 
-1. `lite`: reports the resource `.metadata` and `.status` (where applicable) sections to RazeeDash.
-1. `detail`: reports the entire resource to RazeeDash, but redacts all environment variables from resources and data values from ConfigMaps and Secrets.
-1. `debug`: reports the entire resource to RazeeDash. All data is reported, including Secret values.
+1. `lite`: reports the resource `.metadata` and `.status` (where applicable) sections
+to RazeeDash.
+1. `detail`: reports the entire resource to RazeeDash, but redacts all environment
+variables from resources and data values from ConfigMaps and Secrets.
+1. `debug`: reports the entire resource to RazeeDash. All data is reported, including
+Secret values.
 
 ### Notes
 
 1. `<levels>` must be lower case
-1. Labeling namespaces, especially using the detail or debug level collections, can gather much more data than anticipated resulting in delays in data reporting.
-1. Similarly,  delays can occur when reporting on a namespace with lots of resources (> thousand).
+1. Labeling namespaces, especially using the detail or debug level collections,
+can gather much more data than anticipated resulting in delays in data reporting.
+1. Similarly,  delays can occur when reporting on a namespace with lots of resources
+(> thousand).
 
 ### Watch By Resource
 
-In order to avoid having to label each individual resource, we allow watching by resource kind. Note: [white/black lists](#whiteblack-lists) do not affect watching.
+In order to avoid having to label each individual resource, we allow watching by
+resource kind. Note: [white/black lists](#whiteblack-lists) do not affect watching.
 
-To watch a resource kind, add it to the `watch-keeper-non-namespaced` ConfigMap in the form `apiVersion_kind` (where any `/` is replaced with an `_`).
+To watch a resource kind, add it to the `watch-keeper-non-namespaced` ConfigMap
+in the form `apiVersion_kind` (where any `/` is replaced with an `_`).
 
 ```yaml
 apiVersion: v1
@@ -73,13 +100,17 @@ data:
 
 ### Non-Namespaced Resources
 
-In order to avoid having to label each individual non-namespaced resource (eg. nodes, namespaces, customresourcedefinitions),
-we allow polling of all non-namespaced resource. This mechanism is similar to how our namespace resource collection works,
-where you can label a namespace and we collect all the resources within that namespace for you; you can think of this like you are labeling the `non-namespaced-resources` namespace.
+In order to avoid having to label each individual non-namespaced resource (eg. nodes,
+namespaces, customresourcedefinitions), we allow polling of all non-namespaced resource.
+This mechanism is similar to how our namespace resource collection works, where
+you can label a namespace and we collect all the resources within that namespace
+for you; you can think of this like you are labeling the `non-namespaced-resources`
+namespace.
 
-Also similar to how you can label a namespace, there may be resources that you do not want to collect (eg. storageclass), so
-you should use [white/black lists](#whiteblack-lists) to limit what is collected. Note: using the white/black list will
-affect all resources polled, namespaced and non-namespace.
+Also similar to how you can label a namespace, there may be resources that you do
+not want to collect (eg. storageclass), so you should use [white/black lists](#whiteblack-lists)
+to limit what is collected. Note: using the white/black list will affect all resources
+polled, namespaced and non-namespace.
 
 ```yaml
 apiVersion: v1
@@ -106,10 +137,11 @@ labeled to be watched will still be watched, regardless of the white/black list.
 #### Creating a White/Black List
 
 - To create your white/black list, the ConfigMap will specify the kind of list
-you want as the first key, and the rest of the ConfigMap entries become the white/black list.
-- The white/black list itself are the ConfigMap entries:
+you want as the first key, and the rest of the ConfigMap entries become the white/black
+list.
+- The white/black list itself is created from the ConfigMap keys:
   - The keys will be `apiVersion_kind` (where any `/` is replaced with an `_`).
-  - The value will be `'true'`.
+  - The value must be `'true'`.
 
 ```yaml
 apiVersion: v1
@@ -118,10 +150,10 @@ metadata:
   name: watch-keeper-limit-poll
   namespace: <watch-keeper ns>
 data:
-  # Type of list
+  # Type of list (must be 'true')
   whitelist: 'true'
 
-  # Resources affected
+  # Resources affected (must be 'true')
   v1_node: 'true'
   v1_namespace: 'true'
   apps_v1_deployment: 'true'
@@ -131,21 +163,38 @@ data:
 
 ## Feature Intervals
 
-Watch-Keeper collects and reports on data in a few different ways. Each of these ways is on a differently timed interval and affects when data populates/updates in RazeeDash. These intervals are configurable via environment variables defined in the deployment yaml (note: Intervals are in minutes and should follow: CLEAN_START_INTERVAL > POLL_INTERVAL > VALIDATE_INTERVAL).
+Watch-Keeper collects and reports on data in a few different ways. Each of these
+ways is on a differently timed interval and affects when data populates/updates
+in RazeeDash. These intervals are configurable via environment variables defined
+in the deployment yaml (note: Intervals are in minutes and should follow:
+`CLEAN_START_INTERVAL > POLL_INTERVAL > VALIDATE_INTERVAL`. ie. 1440 > 60 > 10).
 
-1. Heartbeat: every heartbeat collects the user defined [cluster metadata](#cluster-metadata), the cluster id, and the cluster kube version, and sends the data to RazeeDash.
+1. Heartbeat: every heartbeat collects the user defined [cluster metadata](#cluster-metadata),
+the cluster id, and the cluster kube version, and sends the data to RazeeDash.
     - Timing: `1 minute` (non configurable)
-1. Validate Watched Resources:  every `VALIDATE_INTERVAL` minutes, watch keeper will make sure it has a watch created for the resource kinds (eg. apps/v1 Deployment) that have at least one resource instance with the label. This means the first time you add the label to a previously unwatched resource kind, it could take up to `VALIDATE_INTERVAL` minutes to show in razeedash.
+1. Validate Watched Resources:  every `VALIDATE_INTERVAL` minutes, watch keeper
+will make sure it has a watch created for the resource kinds (eg. apps/v1 Deployment)
+that have at least one resource instance with the label. This means the first time
+you add the label to a previously unwatched resource kind, it could take up to
+`VALIDATE_INTERVAL` minutes to show in razeedash.
     - Timing: `VALIDATE_INTERVAL=10`
-1. Poll labeled Resources: every `POLL_INTERVAL` minutes, watch keeper will find all resources with the `razee/watch-resource` label and send to RazeeDash, as well as find all namespaces with the `razee/watch-resource` label and collects/reports all resources within those namespaces.
+1. Poll labeled Resources: every `POLL_INTERVAL` minutes, watch keeper will find
+all resources with the `razee/watch-resource` label and send to RazeeDash, as well
+as find all namespaces with the `razee/watch-resource` label and collects/reports
+all resources within those namespaces.
     - Timing: `POLL_INTERVAL=60`
-    - coming soon: RazeeDash will have a way to force a re-polling. This will be communicated during the heartbeat, and may take a minute to occur.
-1. Clean Start: this is a housekeeping interval. It clears out all watches, and re-verifies watches it should have. Default is once a day.
+    - coming soon: RazeeDash will have a way to force a re-polling. This will be
+    communicated during the heartbeat, and may take a minute to occur.
+1. Clean Start: this is a housekeeping interval. It clears out all watches, and
+re-verifies watches it should have. Default is once a day.
     - Timing: `CLEAN_START_INTERVAL=1440`
 
 ## Cluster Metadata
 
-You can add extra cluster metadata to send to RazeeDash. This can help differentiate clusters on RazeeDash and be more human readable than a uuid. To do this, add the label `razee/cluster-metadata=true` to a configmap. If the configmap contains the key `name`, RazeeDash will display the name instead of the uuid.
+You can add extra cluster metadata to send to RazeeDash. This can help differentiate
+clusters on RazeeDash and be more human readable than a uuid. To do this, add the
+label `razee/cluster-metadata=true` to a configmap. If the configmap contains the
+key `name`, RazeeDash will display the name instead of the uuid.
 
 ```shell
 kubectl create cm my-watch-keeper-cm --from-literal=name=mySpecialDevCluster
@@ -154,15 +203,18 @@ kubectl label cm my-watch-keeper-cm razee/cluster-metadata=true
 
 ## Resource Metadata
 
-You can add extra annotations to your resources in order to help the RazeeDash dashboard link to your change management system.
+You can add extra annotations to your resources in order to help the RazeeDash
+dashboard link to your change management system.
 
 - Working with github:
-  1. `kubectl annotate <resource-kind> <resource-name> "razee.io/git-repo=<github repo>"`
+  1. `kubectl annotate <resource-kind> <resource-name> "razee.io/git-repo=<github-repo>"`
       - eg. `"razee.io/git-repo=https://github.com/razee-io/Watch-keeper"`
-  1. `kubectl annotate <resource-kind> <resource-name> "razee.io/commit-sha=<github sha>"`
+  1. `kubectl annotate <resource-kind> <resource-name> "razee.io/commit-sha=<github-sha>"`
       - eg. `"razee.io/commit-sha=c6645609f8d3b8a48d53246fb7c1f6b60d054aef"`
-  1. **Note**: We find it best practice to collect this info and add them to your resource yamls at build time instead of doing it manually on your cluster.
+  1. **Note**: We find it best practice to collect this info and add them to your
+  resource yamls at build time instead of doing it manually on your cluster.
 - Working with any change management system:
-  1. `kubectl annotate <resource-kind> <resource-name> "razee.io/source-url=<fully qualified path>"`
+  1. `kubectl annotate <resource-kind> <resource-name> "razee.io/source-url=<fully-qualified-path>"`
       - eg. `"razee.io/source-url=https://github.com/razee-io/Watch-keeper/commit/c6645609f8d3b8a48d53246fb7c1f6b60d054aef"`
-  1. **Note**: We find it best practice to collect this info and add them to your resource yamls at build time instead of doing it manually on your cluster.
+  1. **Note**: We find it best practice to collect this info and add them to your
+  resource yamls at build time instead of doing it manually on your cluster.

--- a/package-lock.json
+++ b/package-lock.json
@@ -439,9 +439,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -4249,9 +4249,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "lcid": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "KUBECONFIG=./testdata/kubeconfig.yaml nyc --all --reporter=html --reporter=text mocha ",
     "test:debug": "KUBECONFIG=./testdata/kubeconfig.yaml mocha --inspect-brk",
     "check-coverage": "KUBECONFIG=./testdata/kubeconfig.yaml nyc check-coverage --statements 35 --branches 20 --functions 25 --lines 35",
-    "lint": "run-s eslint dockerlint yamllint jsonlint shlint",
+    "lint": "run-s eslint dockerlint yamllint jsonlint shlint markdownlint",
     "eslint": "npx eslint src/ test/",
     "dockerlint": "npx dockerlint Dockerfile",
     "jsonlint": "npx jsonlint --quiet .eslintrc.json && npx jsonlint --quiet build/viewTemplate.json && npx jsonlint --quiet package.json && npx jsonlint --quiet package-lock.json",

--- a/src/controllers/Poll.js
+++ b/src/controllers/Poll.js
@@ -141,48 +141,87 @@ function resourceFormatter(o, level) {
   return res;
 }
 
-async function readJsonFile(path) {
-  if (await fs.pathExists(path)) {
+async function readWBList() {
+  if (await fs.pathExists('limit-poll/whitelist') && (await fs.readFile('limit-poll/whitelist', 'utf8')).trim() === 'true') {
+    let wlist = await walk('limit-poll', ['whitelist.json', 'whitelist', 'blacklist.json', 'blacklist']);
+    return { whitelist: wlist };
+
+  } else if (await fs.pathExists('limit-poll/blacklist') && (await fs.readFile('limit-poll/blacklist', 'utf8')).trim() === 'true') {
+    let blist = await walk('limit-poll', ['whitelist.json', 'whitelist', 'blacklist.json', 'blacklist']);
+    return { blacklist: blist };
+
+  } else if (await fs.pathExists('limit-poll/whitelist.json')) {
     try {
-      return await fs.readJson(path);
+      let wlistJson = await fs.readJson('limit-poll/whitelist.json');
+      let flattenedList = flattenJsonListObj(wlistJson);
+      return { whitelist: flattenedList };
+    } catch (e) {
+      log.error(e);
+    }
+
+  } else if (await fs.pathExists('limit-poll/blacklist.json')) {
+    try {
+      let blistJson = await fs.readJson('limit-poll/blacklist.json');
+      let flattenedList = flattenJsonListObj(blistJson);
+      return { blacklist: flattenedList };
     } catch (e) {
       log.error(e);
     }
   }
-  return;
+  return {};
 }
 
-function listContains(list, ...search) {
-  for (var i = 0; i < list.length; i++) {
-    for (var j = 0; j < search.length; j++) {
-      if (list[i].toLowerCase() == search[j].toLowerCase()) {
-        return true;
-      }
+async function walk(dir, excludeList = []) {
+  let filelist = {};
+  var path = path || require('path');
+  let dirContents = await fs.readdir(dir);
+  for (const file of dirContents) {
+    if (!fs.statSync(path.join(dir, file)).isDirectory() && !excludeList.includes(file.toLowerCase())) {
+      objectPath.set(filelist, [file], (await fs.readFile(path.join(dir, file), 'utf8')).trim());
     }
-
   }
-  return false;
+  return filelist;
 }
 
-async function selectiveListTrim(metaResources, whitelist, blacklist) {
+function flattenJsonListObj(jsonObj) {
+  let fileList = {};
+  let apiVersions = Object.keys(jsonObj);
+  for (let av of apiVersions) {
+    let avStr = av.replace(/\//g, '_');
+    jsonObj[av].forEach(el => fileList[`${avStr.toLowerCase()}_${el.toLowerCase()}`] = 'true');
+  }
+  return fileList;
+}
+
+function objIncludes(obj, ...searchStrs) {
+  searchStrs = searchStrs.map(el => el.toLowerCase());
+  let keys = Object.keys(obj);
+
+  let key = keys.find(el => searchStrs.includes(el.toLowerCase()));
+  if (key) {
+    return { key: key, value: obj[key] };
+  }
+  return {};
+}
+
+async function selectiveListTrim(metaResources) {
+  let { whitelist, blacklist } = await readWBList();
   if (!whitelist && !blacklist) {
     return metaResources;
   }
 
   let result = [];
-  metaResources.map(mr => {
-    let apiVersion = mr.path.replace(/\/(api)s?\//, '');
-    let kind = mr.kind;
-    let name = mr.name;
+  metaResources.map(krm => {
+    let apiVersion = krm.path.replace(/\/(api)s?\//, '').replace(/\//g, '_');
 
-    if (!name.endsWith('/status')) {
+    if (!krm.name.endsWith('/status')) {
       if (whitelist) {
-        if (Array.isArray(whitelist[apiVersion]) && listContains(whitelist[apiVersion], kind, name)) {
-          result.push(mr);
+        if (objIncludes(whitelist, `${apiVersion}_${krm.kind}`, `${apiVersion}_${krm.name}`).value === 'true') {
+          result.push(krm);
         }
       } else if (blacklist) {
-        if (!(Array.isArray(blacklist[apiVersion]) && listContains(blacklist[apiVersion], kind, name))) {
-          result.push(mr);
+        if (!(objIncludes(blacklist, `${apiVersion}_${krm.kind}`, `${apiVersion}_${krm.name}`).value === 'true')) {
+          result.push(krm);
         }
       }
     }
@@ -194,7 +233,8 @@ async function selectiveListTrim(metaResources, whitelist, blacklist) {
 // doesnt have any resources on the system. This takes a while up front, but
 // should save time for the rest of the calls
 async function trimMetaResources(metaResources) {
-  metaResources = await selectiveListTrim(metaResources, await readJsonFile('limit-poll/whitelist.json'), await readJsonFile('limit-poll/blacklist.json'));
+  metaResources = await selectiveListTrim(metaResources);
+  console.dir(metaResources.map(krm => krm.uri()), { depth: null });
 
   // eslint-disable-next-line require-atomic-updates
   util = util || await Util.fetch();
@@ -224,9 +264,15 @@ async function poll() {
   try {
     metaResources = await kc.getKubeResourcesMeta('get');
     metaResources = await trimMetaResources(metaResources);
+    if (metaResources.length < 1) {
+      log.info('No resources found to poll (either due to no resources being labeled or white/black list configuration)');
+      log.info('Finished Polling Resources ============');
+      return success;
+    }
   } catch (e) {
     util.error(`Error querying Kubernetes resources supporting 'get' verb. ${e}`);
-    return false;
+    success = false;
+    return success;
   }
   // must be run sequentially in order of declining detail. Razeedash sender keeps track of what it has sent,
   // and only sends the first instance.. so we want to send the most detailed things first.

--- a/src/controllers/Poll.js
+++ b/src/controllers/Poll.js
@@ -188,7 +188,7 @@ function flattenJsonListObj(jsonObj) {
   let apiVersions = Object.keys(jsonObj);
   for (let av of apiVersions) {
     let avStr = av.replace(/\//g, '_');
-    jsonObj[av].forEach(el => fileList[`${avStr.toLowerCase()}_${el.toLowerCase()}`] = 'true');
+    jsonObj[av].forEach(el => fileList[`${avStr.toLowerCase()}_${el.replace(/\//g, '_').toLowerCase()}`] = 'true');
   }
   return fileList;
 }
@@ -213,14 +213,16 @@ async function selectiveListTrim(metaResources) {
   let result = [];
   metaResources.map(krm => {
     let apiVersion = krm.path.replace(/\/(api)s?\//, '').replace(/\//g, '_');
+    let kind = krm.kind.replace(/\//g, '_');
+    let name = krm.name.replace(/\//g, '_');
 
     if (!krm.name.endsWith('/status')) {
       if (whitelist) {
-        if (objIncludes(whitelist, `${apiVersion}_${krm.kind}`, `${apiVersion}_${krm.name}`).value === 'true') {
+        if (objIncludes(whitelist, `${apiVersion}_${kind}`, `${apiVersion}_${name}`).value === 'true') {
           result.push(krm);
         }
       } else if (blacklist) {
-        if (!(objIncludes(blacklist, `${apiVersion}_${krm.kind}`, `${apiVersion}_${krm.name}`).value === 'true')) {
+        if (!(objIncludes(blacklist, `${apiVersion}_${kind}`, `${apiVersion}_${name}`).value === 'true')) {
           result.push(krm);
         }
       }
@@ -234,7 +236,6 @@ async function selectiveListTrim(metaResources) {
 // should save time for the rest of the calls
 async function trimMetaResources(metaResources) {
   metaResources = await selectiveListTrim(metaResources);
-  console.dir(metaResources.map(krm => krm.uri()), { depth: null });
 
   // eslint-disable-next-line require-atomic-updates
   util = util || await Util.fetch();

--- a/src/controllers/Watch.js
+++ b/src/controllers/Watch.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 const objectPath = require('object-path');
+const fs = require('fs-extra');
 
 const log = require('../bunyan-api').createLogger('Watch');
 const WatchManager = require('../kubernetes/WatchManager')();
@@ -27,17 +28,22 @@ async function validateWatches(watchableKrm, itemsLength, resourceContinue) {
   if (itemsLength === 0 && (resourceContinue === undefined || resourceContinue === '')) {
     WatchManager.removeWatch(watchableKrm.uri({ watch: true }));
   } else {
-    let options = {
-      logger: require('../bunyan-api').createLogger('Watchman'),
-      requestOptions: KubeApiConfig(),
-      watchUri: watchableKrm.uri({ watch: true })
-    };
-    options.requestOptions.qs = { labelSelector: `razee/watch-resource in (true,debug,${Util.liteSynonyms()},${Util.detailSynonyms()})` };
-    WatchManager.ensureWatch(options, (data) => {
-      Util.prepObject2Send(data);
-      util.dsa.send(data);
-    });
+    let querySelector = { labelSelector: `razee/watch-resource in (true,debug,${Util.liteSynonyms()},${Util.detailSynonyms()})` };
+    createWatch(watchableKrm, querySelector);
   }
+}
+
+function createWatch(watchableKrm, querySelector = {}, detailLevel) {
+  let options = {
+    logger: require('../bunyan-api').createLogger('Watchman'),
+    requestOptions: KubeApiConfig(),
+    watchUri: watchableKrm.uri({ watch: true })
+  };
+  options.requestOptions.qs = querySelector;
+  WatchManager.ensureWatch(options, (data) => {
+    Util.prepObject2Send(data, detailLevel);
+    util.dsa.send(data);
+  });
 }
 
 function removeAllWatches() {
@@ -49,20 +55,52 @@ async function watch() {
   let success = true;
   // eslint-disable-next-line require-atomic-updates
   util = util || await Util.fetch();
+  await fs.ensureDir('non-namespaced');
+  let clusterWideWatch = await walk('non-namespaced', ['poll']);
   let resourcesMeta = await kc.getKubeResourcesMeta('watch');
-  let selector = { labelSelector: `razee/watch-resource in (true,debug,${Util.liteSynonyms()},${Util.detailSynonyms()})`, limit: 500 };
+
   try {
     for (var i = 0; i < resourcesMeta.length; i++) {
-      let resource = await kc.getResource(resourcesMeta[i], selector);
-      if (resource.statusCode === 200) {
-        await validateWatches(resourcesMeta[i], objectPath.get(resource, 'object.items.length', 0), objectPath.get(resource, 'object.metadata.continue'));
+      let krm = resourcesMeta[i];
+      let apiVersion = krm.path.replace(/\/(api)s?\//, '').replace(/\//g, '_');
+      let detailLevel = objIncludes(clusterWideWatch, `${apiVersion}_${krm.kind}`, `${apiVersion}_${krm.name}`).value;
+      if (detailLevel) {
+        createWatch(krm, {}, detailLevel);
+      } else {
+        let resource = await kc.getResource(resourcesMeta[i], { labelSelector: `razee/watch-resource in (true,debug,${Util.liteSynonyms()},${Util.detailSynonyms()})`, limit: 500 });
+        if (resource.statusCode === 200) {
+          await validateWatches(resourcesMeta[i], objectPath.get(resource, 'object.items.length', 0), objectPath.get(resource, 'object.metadata.continue'));
+        }
       }
     }
   } catch (e) {
-    util.error(`Could not handle selector. ${JSON.stringify(selector)}`, e);
+    util.error(`Could not validate watches. ${e}`);
     success = false;
   }
   return success;
+}
+
+function objIncludes(obj, ...searchStrs) {
+  searchStrs = searchStrs.map(el => el.toLowerCase());
+  let keys = Object.keys(obj);
+
+  let key = keys.find(el => searchStrs.includes(el.toLowerCase()));
+  if (key) {
+    return { key: key, value: obj[key] };
+  }
+  return {};
+}
+
+async function walk(dir, excludeList = []) {
+  let filelist = {};
+  var path = path || require('path');
+  let dirContents = await fs.readdir(dir);
+  for (const file of dirContents) {
+    if (!fs.statSync(path.join(dir, file)).isDirectory() && !excludeList.includes(file.toLowerCase())) {
+      objectPath.set(filelist, [file], (await fs.readFile(path.join(dir, file), 'utf8')).trim());
+    }
+  }
+  return filelist;
 }
 
 module.exports = {

--- a/src/controllers/Watch.js
+++ b/src/controllers/Watch.js
@@ -33,7 +33,7 @@ async function validateWatches(watchableKrm, itemsLength, resourceContinue) {
   }
 }
 
-function createWatch(watchableKrm, querySelector = {}, detailLevel, force = false) {
+function createWatch(watchableKrm, querySelector = {}, detailLevel, globalWatch = false) {
   let options = {
     logger: require('../bunyan-api').createLogger('Watchman'),
     requestOptions: KubeApiConfig(),
@@ -43,7 +43,7 @@ function createWatch(watchableKrm, querySelector = {}, detailLevel, force = fals
   WatchManager.ensureWatch(options, (data) => {
     Util.prepObject2Send(data, detailLevel);
     util.dsa.send(data);
-  }, force);
+  }, globalWatch);
 }
 
 function removeAllWatches() {
@@ -68,8 +68,9 @@ async function watch() {
 
       let detailLevel = objIncludes(clusterWideWatch, `${apiVersion}_${kind}`, `${apiVersion}_${name}`).value;
       if (detailLevel) {
-        let force = true;
-        createWatch(krm, {}, detailLevel, force);
+        let globalWatch = true;
+        let qs = {};
+        createWatch(krm, qs, detailLevel, globalWatch);
       } else {
         let resource = await kc.getResource(resourcesMeta[i], { labelSelector: `razee/watch-resource in (true,debug,${Util.liteSynonyms()},${Util.detailSynonyms()})`, limit: 500 });
         if (resource.statusCode === 200) {

--- a/src/controllers/Watch.js
+++ b/src/controllers/Watch.js
@@ -63,7 +63,10 @@ async function watch() {
     for (var i = 0; i < resourcesMeta.length; i++) {
       let krm = resourcesMeta[i];
       let apiVersion = krm.path.replace(/\/(api)s?\//, '').replace(/\//g, '_');
-      let detailLevel = objIncludes(clusterWideWatch, `${apiVersion}_${krm.kind}`, `${apiVersion}_${krm.name}`).value;
+      let kind = krm.kind.replace(/\//g, '_');
+      let name = krm.name.replace(/\//g, '_');
+
+      let detailLevel = objIncludes(clusterWideWatch, `${apiVersion}_${kind}`, `${apiVersion}_${name}`).value;
       if (detailLevel) {
         createWatch(krm, {}, detailLevel);
       } else {

--- a/src/controllers/Watch.js
+++ b/src/controllers/Watch.js
@@ -33,7 +33,7 @@ async function validateWatches(watchableKrm, itemsLength, resourceContinue) {
   }
 }
 
-function createWatch(watchableKrm, querySelector = {}, detailLevel) {
+function createWatch(watchableKrm, querySelector = {}, detailLevel, force = false) {
   let options = {
     logger: require('../bunyan-api').createLogger('Watchman'),
     requestOptions: KubeApiConfig(),
@@ -43,7 +43,7 @@ function createWatch(watchableKrm, querySelector = {}, detailLevel) {
   WatchManager.ensureWatch(options, (data) => {
     Util.prepObject2Send(data, detailLevel);
     util.dsa.send(data);
-  });
+  }, force);
 }
 
 function removeAllWatches() {
@@ -68,7 +68,8 @@ async function watch() {
 
       let detailLevel = objIncludes(clusterWideWatch, `${apiVersion}_${kind}`, `${apiVersion}_${name}`).value;
       if (detailLevel) {
-        createWatch(krm, {}, detailLevel);
+        let force = true;
+        createWatch(krm, {}, detailLevel, force);
       } else {
         let resource = await kc.getResource(resourcesMeta[i], { labelSelector: `razee/watch-resource in (true,debug,${Util.liteSynonyms()},${Util.detailSynonyms()})`, limit: 500 });
         if (resource.statusCode === 200) {

--- a/src/kubernetes/WatchManager.js
+++ b/src/kubernetes/WatchManager.js
@@ -21,14 +21,14 @@ var _watchObjects = {};
 
 module.exports = function WatchManager() {
   // private
-  let _saveWatch = function (wm, startWatch = true) {
+  let _saveWatch = function (wm, startWatch = true, qs) {
     let selfLink = wm.selfLink;
     _removeWatch(selfLink);
     _watchObjects[selfLink] = wm;
     if (startWatch) {
       _watchObjects[selfLink].watch();
     }
-    log.info(`Watch added: ${selfLink}`);
+    log.info(`Watch added: ${selfLink} ${JSON.stringify(qs)}`);
     return _watchObjects[selfLink];
   };
 
@@ -38,7 +38,7 @@ module.exports = function WatchManager() {
       return w;
     }
     var wm = new Watchman(options, objectHandler);
-    return _saveWatch(wm, startWatch);
+    return _saveWatch(wm, startWatch, options.requestOptions.qs);
   };
 
   let _startWatch = function (selfLink) {

--- a/src/kubernetes/WatchManager.js
+++ b/src/kubernetes/WatchManager.js
@@ -28,19 +28,17 @@ module.exports = function WatchManager() {
     _removeWatch(selfLink);
     _watchObjects[selfLink] = { selfLink: wm.selfLink, watchman: wm, querySelectorHash: hash(querySelector) };
     if (startWatch) {
-      let wm = objectPath.get(_watchObjects, [selfLink, 'watchman']);
       wm.watch();
     }
     log.info(`Watch added: ${selfLink} ${JSON.stringify(querySelector)}`);
     return _watchObjects[selfLink];
   };
 
-  let _ensureWatch = function (options, objectHandler, force = false, startWatch = true) {
+  let _ensureWatch = function (options, objectHandler, globalWatch = false, startWatch = true) {
     let querySelector = objectPath.get(options, 'requestOptions.qs', {});
     let selfLink = options.watchUri;
     let w = _getWatch(selfLink);
-    if (w && (!force || (force && w.querySelectorHash == hash(querySelector)))) {
-      console.log(`using existing watch.. force=${force} hash=${w.querySelectorHash == hash(querySelector)}`);
+    if (w && (!globalWatch || (globalWatch && w.querySelectorHash == hash(querySelector)))) {
       return w;
     }
     var wm = new Watchman(options, objectHandler);

--- a/test/Util-test.js
+++ b/test/Util-test.js
@@ -254,7 +254,7 @@ describe('Util', () => {
     });
     it('redact Secret', () => {
       let result = Util.prepObject2Send({ kind: 'Secret', metadata: { labels: { 'razee/watch-resource': 'detail' } }, data: { a: 'a', b: 'b' } });
-      console.dir(result, { depth: null });
+      // console.dir(result, { depth: null });
       assert.equal(result.data.a, 'REDACTED');
       assert.equal(result.data.b, 'REDACTED');
     });

--- a/test/Watch-test.js
+++ b/test/Watch-test.js
@@ -75,15 +75,18 @@ describe('Watch', () => {
         }
       });
       let mockWatchManager = {
-        ensureWatch: (options, objectHandler) => { 
+        ensureWatch: (options, objectHandler) => {
           return objectHandler(TEST_POD);
         }
       };
       let mockKubeClass = {
-        getKubeResourcesMeta: () => { 
+        getKubeResourcesMeta: () => {
           return Promise.resolve([{
             '_path': '/api/v1',
             'uri': () => '/api/v1/endpoints/watch',
+            'path': '/api/v1',
+            'kind': 'Endpoints',
+            'name': 'endpoints',
             '_resourceMeta': {
               'name': 'endpoints',
               'singularName': '',
@@ -95,7 +98,7 @@ describe('Watch', () => {
           }]);
         },
         // eslint-disable-next-line no-unused-vars
-        getResource: async (resourceMeta, queryParms) => { 
+        getResource: async (resourceMeta, queryParms) => {
           return Promise.resolve({
             'resource-metadata': {
               '_path': '/api/v1',
@@ -171,7 +174,7 @@ describe('Watch', () => {
         getClusterMeta: () => { return {}; }
       });
       let mockWatchManager = {
-        ensureWatch: (options, objectHandler) => { 
+        ensureWatch: (options, objectHandler) => {
           return objectHandler(TEST_POD);
         }
       };
@@ -180,6 +183,9 @@ describe('Watch', () => {
           return Promise.resolve([{
             '_path': '/api/v1',
             'uri': () => '/api/v1/endpoints/watch',
+            'path': '/api/v1',
+            'kind': 'Endpoints',
+            'name': 'endpoints',
             '_resourceMeta': {
               'name': 'endpoints',
               'singularName': '',
@@ -224,6 +230,9 @@ describe('Watch', () => {
           return Promise.resolve([{
             '_path': '/api/v1',
             'uri': () => '/api/v1/endpoints/watch',
+            'path': '/api/v1',
+            'kind': 'Endpoints',
+            'name': 'endpoints',
             '_resourceMeta': {
               'name': 'endpoints',
               'singularName': '',
@@ -290,6 +299,9 @@ describe('Watch', () => {
           return Promise.resolve([{
             '_path': '/api/v1',
             'uri': () => '/api/v1/endpoints/watch',
+            'path': '/api/v1',
+            'kind': 'Endpoints',
+            'name': 'endpoints',
             '_resourceMeta': {
               'name': 'endpoints',
               'singularName': '',


### PR DESCRIPTION
Allow user to specify resources to watch without having to label individual resources to watch. This allows for watching of non-namespaced resource (ie. namespaces and nodes) as well as namespaced resources across all namespaces.

Update white/black list UX to match watching. Updates the user experience around creating white/black list to match the experience with the watch across namespace feature. Change maintains backward compatibility. 

Update readme to reflect new features and changes