### PR TITLE
Fix: Properly handle event objects

### DIFF
--- a/src/controllers/Util.js
+++ b/src/controllers/Util.js
@@ -130,11 +130,13 @@ module.exports = class Util {
   // prepObject2Send - strip/redact attributes and apply razeehash code if needed
   static prepObject2Send(o, level = 'lite') {
     if (Array.isArray(o)) {
-      o.forEach(Util.prepObject2Send);
+      return o.map(el => Util.prepObject2Send(el, level));
     } else if (Array.isArray(o.items)) {
-      o.items.forEach(Util.prepObject2Send);
+      o.items = o.items.map(el => Util.prepObject2Send(el, level));
+      return o;
     } else if (o.object) {
-      Util.prepObject2Send(o.object);
+      o.object = Util.prepObject2Send(o.object, level);
+      return o;
     } else {
       let labelLevel = objectPath.get(o, ['metadata', 'labels', 'razee/watch-resource'], level);
       if (labelLevel == 'debug') {

--- a/src/controllers/Watch.js
+++ b/src/controllers/Watch.js
@@ -40,9 +40,9 @@ function createWatch(watchableKrm, querySelector = {}, detailLevel, globalWatch 
     watchUri: watchableKrm.uri({ watch: true })
   };
   options.requestOptions.qs = querySelector;
-  WatchManager.ensureWatch(options, (data) => {
-    Util.prepObject2Send(data, detailLevel);
-    util.dsa.send(data);
+  WatchManager.ensureWatch(options, (eventObj) => {
+    let preppedEventObj = Util.prepObject2Send(eventObj, detailLevel);
+    util.dsa.send(preppedEventObj);
   }, globalWatch);
 }
 


### PR DESCRIPTION
`Watch` event data comes through with the actual data in the subproperty `object`. should properly handle this nested case when prepping object to send.