### PR TITLE
Build: publish release with rbac for those still using it (fixes #103)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   - if [ -n "${TRAVIS_TAG}" ]; then docker tag quay.io/razee/watch-keeper:${TRAVIS_COMMIT} quay.io/razee/watch-keeper:${TRAVIS_TAG}; fi
   - docker images
   - ./build/process-template.sh kubernetes/watch-keeper/resource.yaml >/tmp/resource.yaml
+  - ./build/process-template.sh kubernetes/watch-keeper/rbac.yaml >/tmp/rbac.yaml
 
 before_deploy:
   - docker login -u="${QUAY_ID}" -p="${QUAY_TOKEN}" quay.io
@@ -35,7 +36,9 @@ deploy:
       tags: true
       condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$
   - provider: releases
-    file: /tmp/resource.yaml
+    file:
+      - "/tmp/resource.yaml"
+      - "/tmp/rbac.yaml"
     skip_cleanup: true
     api_key: "${GITHUB_TOKEN}"
     name: "${TRAVIS_TAG}"

--- a/kubernetes/watch-keeper/rbac.yaml
+++ b/kubernetes/watch-keeper/rbac.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: watch-keeper-deployment
+  annotations:
+    version: "{{TRAVIS_COMMIT}}"
+type: array
+items:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: razeedeploy
+      labels:
+        deploy.razee.io/mode: "EnsureExists"
+        deploy.razee.io/Reconcile: "false"
+      annotations:
+        razee.io/git-repo: "{{{GIT_REMOTE}}}"
+        razee.io/commit-sha: "{{TRAVIS_COMMIT}}"
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: cluster-reader
+      annotations:
+        razee.io/git-repo: "{{{GIT_REMOTE}}}"
+        razee.io/commit-sha: "{{TRAVIS_COMMIT}}"
+    rules:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs: ["get", "list", "watch"]
+    - nonResourceURLs:
+      - '*'
+      verbs: ["get", "list", "watch"]
+
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: watch-keeper-sa
+      namespace: razeedeploy
+      annotations:
+        razee.io/git-repo: "{{{GIT_REMOTE}}}"
+        razee.io/commit-sha: "{{TRAVIS_COMMIT}}"
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: watch-keeper-rb
+      annotations:
+        razee.io/git-repo: "{{{GIT_REMOTE}}}"
+        razee.io/commit-sha: "{{TRAVIS_COMMIT}}"
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cluster-reader
+    subjects:
+    - kind: ServiceAccount
+      name: watch-keeper-sa
+      namespace: razeedeploy
+
+  - kind: NetworkPolicy
+    apiVersion: networking.k8s.io/v1
+    metadata:
+      name: watch-keeper-deny-ingress
+      namespace: razeedeploy
+      annotations:
+        razee.io/git-repo: "{{{GIT_REMOTE}}}"
+        razee.io/commit-sha: "{{TRAVIS_COMMIT}}"
+    spec:
+      podSelector:
+        matchLabels:
+          app: watch-keeper
+      policyTypes:
+      - Ingress
+      ingress: []


### PR DESCRIPTION
some people say they are not wanting to switch to the install job yet, so we can still publish the RBAC for those that want to manually download and apply watch keeper.