### PR TITLE
Update: Pull KUBECONFIG and CONFIG_NAMESPACE from w-k-config if exists

### DIFF
--- a/kubernetes/watch-keeper/resource.yaml
+++ b/kubernetes/watch-keeper/resource.yaml
@@ -38,8 +38,16 @@ spec:
                 fieldPath: metadata.namespace
           - name: CONFIG_NAMESPACE
             valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+              configMapKeyRef:
+                name: watch-keeper-config
+                key: CONFIG_NAMESPACE
+                optional: true
+          - name: KUBECONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: watch-keeper-config
+                key: KUBECONFIG
+                optional: true
           - name: RAZEEDASH_URL
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
allow for out of cluster watch-keeper by allowing config_namespace and kubeconfig be defined for a different cluster. If they arent defined, CONFIG_NAMESPACE defaults to NAMESPACE and KUBECONFIG defaults to load from in cluster.