### PR TITLE
Update: Use config ns uid as cluster id if defined

### DIFF
--- a/src/controllers/DataCollector.js
+++ b/src/controllers/DataCollector.js
@@ -25,7 +25,7 @@ module.exports = class DataCollector {
     if (this.clusterID) {
       return this.clusterID;
     }
-    let ns = process.env.NAMESPACE || 'kube-system';
+    let ns = process.env.CONFIG_NAMESPACE || process.env.NAMESPACE || 'kube-system';
     let ks = await this.kubeClass.getResource({ uri: () => `/api/v1/namespaces/${ns}` });
     this.clusterID = objectPath.get(ks.object, 'metadata.uid');
     return this.clusterID;


### PR DESCRIPTION
If pointing at seperate cluster and using config_namespace, should also get the uid of that ns because there is no guarantee the cluster you are talking to has the ns you are sitting in.