### PR TITLE
Update: allow CLUSTER_ID_OVERRIDE for data sent to razeedash

### DIFF
--- a/kubernetes/watch-keeper/resource.yaml
+++ b/kubernetes/watch-keeper/resource.yaml
@@ -42,6 +42,12 @@ spec:
                 name: watch-keeper-config
                 key: CONFIG_NAMESPACE
                 optional: true
+          - name: CLUSTER_ID_OVERRIDE
+            valueFrom:
+              configMapKeyRef:
+                name: watch-keeper-config
+                key: CLUSTER_ID_OVERRIDE
+                optional: true
           - name: KUBECONFIG
             valueFrom:
               configMapKeyRef:

--- a/src/controllers/DataCollector.js
+++ b/src/controllers/DataCollector.js
@@ -24,6 +24,9 @@ module.exports = class DataCollector {
   async getClusterUid() {
     if (this.clusterID) {
       return this.clusterID;
+    } else if (process.env.CLUSTER_ID_OVERRIDE) {
+      this.clusterID = process.env.CLUSTER_ID_OVERRIDE;
+      return this.clusterID;
     }
     let ns = process.env.CONFIG_NAMESPACE || process.env.NAMESPACE || 'kube-system';
     let ks = await this.kubeClass.getResource({ uri: () => `/api/v1/namespaces/${ns}` });


### PR DESCRIPTION
without `CLUSTER_ID_OVERRIDE` env set, defaults to the UID of the namespace `process.env.CONFIG_NAMESPACE || process.env.NAMESPACE || 'kube-system';`