### PR TITLE
Update: move envs to volumes to allow for common id config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,6 @@ typings/
 
 ########### Custom ignores ###########
 dev/
+envs/
 limit-poll/
 non-namespaced/

--- a/kubernetes/watch-keeper/resource.yaml
+++ b/kubernetes/watch-keeper/resource.yaml
@@ -26,50 +26,10 @@ spec:
       serviceAccountName: watch-keeper-sa
       containers:
       - env:
-          - name: START_DELAY_MAX
-            valueFrom:
-              configMapKeyRef:
-                name: watch-keeper-config
-                key: START_DELAY_MAX
-                optional: true
           - name: NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: CONFIG_NAMESPACE
-            valueFrom:
-              configMapKeyRef:
-                name: watch-keeper-config
-                key: CONFIG_NAMESPACE
-                optional: true
-          - name: CLUSTER_ID_OVERRIDE
-            valueFrom:
-              configMapKeyRef:
-                name: watch-keeper-config
-                key: CLUSTER_ID_OVERRIDE
-                optional: true
-          - name: DEFAULT_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                name: watch-keeper-config
-                key: DEFAULT_CLUSTER_NAME
-                optional: true
-          - name: KUBECONFIG
-            valueFrom:
-              configMapKeyRef:
-                name: watch-keeper-config
-                key: KUBECONFIG
-                optional: true
-          - name: RAZEEDASH_URL
-            valueFrom:
-              configMapKeyRef:
-                name: watch-keeper-config
-                key: RAZEEDASH_URL
-          - name: RAZEEDASH_ORG_KEY
-            valueFrom:
-              secretKeyRef:
-                name: watch-keeper-secret
-                key: RAZEEDASH_ORG_KEY
           - name: NODE_ENV
             value: "production"
         image: "quay.io/razee/watch-keeper:{{TRAVIS_TAG}}"
@@ -90,3 +50,33 @@ spec:
           periodSeconds: 300
           timeoutSeconds: 30
           failureThreshold: 1
+          volumeMounts:
+            - mountPath: /usr/src/app/envs/watch-keeper-config
+              name: watch-keeper-config
+            - mountPath: /usr/src/app/envs/watch-keeper-secret
+              name: watch-keeper-secret
+            - mountPath: /usr/src/app/envs/razee-identity-config
+              name: razee-identity-config
+            - mountPath: /usr/src/app/envs/razee-identity-secret
+              name: razee-identity-secret
+      volumes:
+        - name: watch-keeper-config
+          configMap:
+            name: watch-keeper-config
+            defaultMode: 0400
+            optional: true
+        - name: watch-keeper-secret
+          secret:
+            secretName: watch-keeper-secret
+            defaultMode: 0400
+            optional: true
+        - name: razee-identity-config
+          configMap:
+            name: razee-identity
+            defaultMode: 0400
+            optional: true
+        - name: razee-identity-secret
+          secret:
+            secretName: razee-identity
+            defaultMode: 0400
+            optional: true

--- a/kubernetes/watch-keeper/resource.yaml
+++ b/kubernetes/watch-keeper/resource.yaml
@@ -50,15 +50,15 @@ spec:
           periodSeconds: 300
           timeoutSeconds: 30
           failureThreshold: 1
-          volumeMounts:
-            - mountPath: /usr/src/app/envs/watch-keeper-config
-              name: watch-keeper-config
-            - mountPath: /usr/src/app/envs/watch-keeper-secret
-              name: watch-keeper-secret
-            - mountPath: /usr/src/app/envs/razee-identity-config
-              name: razee-identity-config
-            - mountPath: /usr/src/app/envs/razee-identity-secret
-              name: razee-identity-secret
+        volumeMounts:
+          - mountPath: /usr/src/app/envs/watch-keeper-config
+            name: watch-keeper-config
+          - mountPath: /usr/src/app/envs/watch-keeper-secret
+            name: watch-keeper-secret
+          - mountPath: /usr/src/app/envs/razee-identity-config
+            name: razee-identity-config
+          - mountPath: /usr/src/app/envs/razee-identity-secret
+            name: razee-identity-secret
       volumes:
         - name: watch-keeper-config
           configMap:

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,21 @@
 /**
-* Copyright 2019 IBM Corp. All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2019 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 const touch = require('touch');
 const promiseRetry = require('promise-retry');
+const fs = require('fs-extra');
 const log = require('./bunyan-api').createLogger('Index');
 
 const Util = require('./controllers/Util');
@@ -65,6 +66,7 @@ async function main() {
 
 async function init() {
   try {
+    await setEnvs();
     util = await Util.fetch();
   } catch (e) {
     const Messenger = require('./razeedash/Messenger');
@@ -91,3 +93,58 @@ promiseRetry({ retries: 5 },
   retry => {
     return init().catch(retry);
   }).catch(err => log.error(`Failed to init watch-keeper | ${err}`));
+
+async function setEnvs() {
+  const env = process.env;
+
+  // Razee Config
+  if (await fs.pathExists('envs/watch-keeper-config/RAZEEDASH_URL')) {
+    env.RAZEEDASH_URL = (await fs.readFile('envs/watch-keeper-config/RAZEEDASH_URL', 'utf8')).trim();
+  } else if (await fs.pathExists('envs/razee-identity-config/RAZEE_API')) {
+    let razeeApi = (await fs.readFile('envs/razee-identity-config/RAZEE_API', 'utf8')).trim();
+    env.RAZEEDASH_URL = `${razeeApi.replace(/\/+$/, '')}/api/v2`;
+  } else {
+    log.error('failed to find Razee url to post data to. exiting(1)');
+    process.exit(1);
+  }
+  if (await fs.pathExists('envs/razee-identity-secret/RAZEE_ORG_KEY')) {
+    env.RAZEEDASH_ORG_KEY = (await fs.readFile('envs/razee-identity-secret/RAZEE_ORG_KEY', 'utf8')).trim();
+  } else if (await fs.pathExists('envs/watch-keeper-secret/RAZEEDASH_ORG_KEY')) {
+    env.RAZEEDASH_ORG_KEY = (await fs.readFile('envs/watch-keeper-secret/RAZEEDASH_ORG_KEY', 'utf8')).trim();
+  }
+  if (await fs.pathExists('envs/razee-identity-config/CLUSTER_ID')) {
+    env.CLUSTER_ID_OVERRIDE = (await fs.readFile('envs/razee-identity-config/CLUSTER_ID', 'utf8')).trim();
+  } else if (await fs.pathExists('envs/watch-keeper-config/CLUSTER_ID_OVERRIDE')) {
+    env.CLUSTER_ID_OVERRIDE = (await fs.readFile('envs/watch-keeper-config/CLUSTER_ID_OVERRIDE', 'utf8')).trim();
+  }
+  if (await fs.pathExists('envs/razee-identity-config/CLUSTER_NAME')) {
+    env.DEFAULT_CLUSTER_NAME = (await fs.readFile('envs/razee-identity-config/CLUSTER_NAME', 'utf8')).trim();
+  } else if (await fs.pathExists('envs/watch-keeper-config/DEFAULT_CLUSTER_NAME')) {
+    env.DEFAULT_CLUSTER_NAME = (await fs.readFile('envs/watch-keeper-config/DEFAULT_CLUSTER_NAME', 'utf8')).trim();
+  }
+
+  // Watch-keeper Specific Config
+  if (await fs.pathExists('envs/watch-keeper-config/START_DELAY_MAX')) {
+    env.START_DELAY_MAX = (await fs.readFile('envs/watch-keeper-config/START_DELAY_MAX', 'utf8')).trim();
+  }
+  if (await fs.pathExists('envs/watch-keeper-config/CONFIG_NAMESPACE')) {
+    env.CONFIG_NAMESPACE = (await fs.readFile('envs/watch-keeper-config/CONFIG_NAMESPACE', 'utf8')).trim();
+  }
+  if (await fs.pathExists('envs/watch-keeper-config/KUBECONFIG')) {
+    env.KUBECONFIG = (await fs.readFile('envs/watch-keeper-config/KUBECONFIG', 'utf8')).trim();
+  } else {
+    env.KUBECONFIG = '/etc/kubernetes/admin-kubeconfig';
+  }
+  if (await fs.pathExists('envs/watch-keeper-config/VALIDATE_INTERVAL')) {
+    env.VALIDATE_INTERVAL = (await fs.readFile('envs/watch-keeper-config/VALIDATE_INTERVAL', 'utf8')).trim();
+  }
+  if (await fs.pathExists('envs/watch-keeper-config/POLL_INTERVAL')) {
+    env.POLL_INTERVAL = (await fs.readFile('envs/watch-keeper-config/POLL_INTERVAL', 'utf8')).trim();
+  }
+  if (await fs.pathExists('envs/watch-keeper-config/CLEAN_START_INTERVAL')) {
+    env.CLEAN_START_INTERVAL = (await fs.readFile('envs/watch-keeper-config/CLEAN_START_INTERVAL', 'utf8')).trim();
+  }
+  if (await fs.pathExists('envs/watch-keeper-config/LOG_LEVEL')) {
+    env.LOG_LEVEL = (await fs.readFile('envs/watch-keeper-config/LOG_LEVEL', 'utf8')).trim();
+  }
+}


### PR DESCRIPTION
Moving to volumes so that we can start allowing use of a common razee-identity configmap/secret that will be shared with clusterSubsription and possibly others in the future.